### PR TITLE
Updated mac-adress notation in the usage Example

### DIFF
--- a/_bindings/amazondashbutton/readme.md
+++ b/_bindings/amazondashbutton/readme.md
@@ -101,7 +101,7 @@ __ Caution:__  You have to be aware that other Amazon devices might pop up in yo
 ```
 rule "Dash button pressed"
     when
-        Channel "amazondashbutton:dashbutton:ac-63-be-xx-xx-xx:press" triggered
+        Channel "amazondashbutton:dashbutton:ac63bexxxxxx:press" triggered
     then
         println("The Dash button has been pressed")
 end


### PR DESCRIPTION
The notation of mac-adresses changed in one of the last updates.
This very small change fixes the example.